### PR TITLE
bump vnet AVM version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,13 +2,14 @@ module "subnets" {
   for_each = local.subnets
 
   source  = "Azure/avm-res-network-virtualnetwork/azurerm//modules/subnet"
-  version = "0.2.3"
+  version = "0.3.0"
 
   virtual_network = {
     resource_id = var.virtual_network_resource_id
   }
   name             = each.value.name
   address_prefixes = each.value.address_prefixes
+  address_prefix   = each.value.address_prefix
 
   default_outbound_access_enabled               = try(each.value.default_outbound_access_enabled, false)
   delegation                                    = try(each.value.delegation, null)


### PR DESCRIPTION
Pulling fix for issue https://github.com/Azure/terraform-azurerm-avm-res-network-virtualnetwork/issues/101 so we can rely on this module for ACA deployment

## Description

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [X] Bugfix containing backwards compatible bug fixes, and I have NOT bumped the MAJOR or MINOR version in `locals.version.tf.json`:
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates, and I have bumped the MINOR version in `locals.version.tf.json`.
  - [ ] Breaking changes and I have bumped the MAJOR version in `locals.version.tf.json`.
  - [ ] Update to documentation

# Checklist

- [X] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
